### PR TITLE
Make ki.ie8.js compatible with IE8 again...

### DIFF
--- a/ki.ie8.js
+++ b/ki.ie8.js
@@ -11,9 +11,10 @@
   /*
    * init function (internal use)
    * a = selector, dom element or function
+   * d = placeholder for index
    */
-  function i(a) {
-    c.push.apply(this, a && a.nodeType ? [a] : '' + a === a ? c.slice.call(b.querySelectorAll(a)) : g);
+  function i(a, d) {
+    for (d in a = a && a.nodeType ? [a] : '' + a === a ? b.querySelectorAll(a) : g) a[d].nodeType - 1 || (this[this.length++] = a[d]);
   }
 
   /*


### PR DESCRIPTION
Alas, [].slice doesn't accept the output of querySelectorAll in IE8. Since throwing errors often offends, we should try to replace it with something that does (alas, I can't do it any shorter at the moment, maybe you've got an idea).
