### PR TITLE
Adds support for array

### DIFF
--- a/ki.js
+++ b/ki.js
@@ -9,8 +9,8 @@
    * init function (internal use)
    * a = selector, dom element or function
    */
-  function i(a) {
-    c.push.apply(this, a && a.nodeType ? [a] : '' + a === a ? b.querySelectorAll(a) : e)
+  function i(a) { 
+    c.push.apply(this, a && a.nodeType ? [a] : a && Object.prototype.toString.call(a) == '[object Array]' ? a : '' + a === a ? b.querySelectorAll(a) : e)
   }
 
   /*


### PR DESCRIPTION
I would like to be able to do something like:

```
var div = $("div.myClass");
div.find("a").each(...)
div.find("a.selected").each(...)
```

However, 
1. There is no support for restricting your dom queries to children of a node via node.querySelectorAll() and returning your class wrapper
2. To add such an extension, I would need the constructor to accept an array of dom nodes as a possible input

So: I can't weigh for you the importance of keeping size down vs supporting array inputs.  What I can show is what my extension looks like:

```
 $.prototype.find = function(a){
    var result = [];
    this.each(function(node) {
        result = result.concat(node.querySelectorAll(a));
    });
    return new i(result);
};
```

Note: required some hacking to get access to the i() function (grunt build script inserts a module.exports.dom = i)
