### PR TITLE
Allow element creation

### DIFF
--- a/ki.js
+++ b/ki.js
@@ -10,7 +10,14 @@
    * a = selector, dom element or function
    */
   function i(a) {
-    c.push.apply(this, a && a.nodeType ? [a] : '' + a === a ? b.querySelectorAll(a) : e)
+    c.push.apply(this, a && a.nodeType ?
+      [a] :
+      '' + a === a ?
+        a[0] === '<' && a[a.length - 1] === '>' ?
+        [b.createElement(a.replace(/^<(\w+)\s*?\/?>[^\n\r\S]*(?:$|<\/\1>)/, '$1'))] :
+        b.querySelectorAll(a) :
+      e
+    )
   }
 
   /*


### PR DESCRIPTION
This change allows us to use `$()` to create new elements as known from jQuery and others in that realm, e.g:

`$('<div>')` will create a new div element, as will `$('<div />')`, `$('<div/>')`, `$('<div></div>')`, nesting stuff within is not supported, e.g. `$('<div><b>I am a nested element</b></div>')` will fail! Also no direct attribute creation, we can do this afterwards with some plugins like `$('<div>').attr('value', 'yes')`, that would be:

```js
$.prototype.attr = function(a, b) {
	return b === []._ ? ( this.length ? this[0].getAttribute(a) : false ) : this.each(function(c) {
		c.setAttribute(a, b);
	});
};
```