### PR TITLE
Inherit all methods from Array.prototype!

### DIFF
--- a/ki.js
+++ b/ki.js
@@ -10,7 +10,7 @@
    * a = selector, dom element or function
    */
   function i(a) {
-    c.push.apply(this, a && a.nodeType ? [a] : '' + a === a ? b.querySelectorAll(a) : e)
+    c.push.apply(this, a && a.nodeType ? [a] : a && Array.isArray(a) ? a : '' + a === a ? ( a[0] === '<' && a[a.length - 1] === '>' ? [b.createElement(a.replace(/^<(\w+)\s*?\/?>[^\n\r\S]*(?:$|<\/\1>)/, '$1'))] : b.querySelectorAll(a) ) : [b.createDocumentFragment()]);
   }
 
   /*
@@ -24,10 +24,7 @@
   }
 
   // set ki prototype
-  $[d] = i[d] = $.fn = i.fn = {
-
-    // default length
-    length: 0,
+  $[d] = i[d] = $.fn = i.fn = Object.create(Array.prototype, {
 
     /*
      * on method
@@ -35,11 +32,11 @@
      * b = function
      * return this
      */
-    on: function (a, b) {
+    on: {value: function (a, b) {
       return this.each(function (c) {
         c.addEventListener(a, b)
       })
-    },
+    }},
 
     /*
      * off method
@@ -47,11 +44,11 @@
      * b = function
      * return this
      */
-    off: function (a, b) {
+    off: {value: function (a, b) {
       return this.each(function (c) {
         c.removeEventListener(a, b)
       })
-    },
+    }},
 
     /*
      * each method
@@ -59,13 +56,9 @@
      * a = the function to call on each iteration
      * b = the this value for that function
      */
-    each: function (a, b) {
+    each: {value: function (a, b) {
       c.forEach.call(this, a, b)
       return this
-    },
-
-    // for some reason is needed to get an array-like
-    // representation instead of an object
-    splice: c.splice
+    }},
   }
 }(document, [], 'prototype');


### PR DESCRIPTION
If we initiate the ki object by inheriting from `Array.prototype`, we can save ourselves some extensions because we can already natively use ALL array methods on our collections (they of course need to be wrapped again in `$()` to make them ki collections, which requires that the constructor (`i` function) can deal with arrays as input, which is one of the additions to the i function here, others are:

- DOM node creation like jQuery by passing HTML-tags, see other PR
- `$()` now returns a documentFragment (nice to construct HTML in memory and then append it to the DOM) instead of a useless empty collection

I know, this all adds valuable bytes, but we can now also remove the `splice` and `length` props as they are inherited by `Array.prototype` and I think the huge gain in functionality out of the box would justify the increase in size.

the native array methods that collide with jQuery methods, like `find()` for example, can still be easily overwritten with an extension like this:

```
$.fn.find = function(a){
	var r = [];
	this.each(function(e) {
		r = r.concat(this.slice.call(e.querySelectorAll(a)));
	});
	return $(r);
};
```

which might be appropriate if we try to mirror jQuery, but in other scenarios the native `.find()` might be enough, who know, that's the nice thing about ki =), it can be extended as needed without having to define a bunch of stuff we might need or not...