### PR TITLE
Add support for array methods

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,3 +3,4 @@ james2doyle <james2doyle@gmail.com>
 Daniel Hug <danielthehug@gmail.com>
 impinball <impinball@gmail.com>
 Comix Dym <such@dym.cx>
+Atmos4 <atmos4.dev@gmail.com>

--- a/ki.js
+++ b/ki.js
@@ -23,12 +23,11 @@
     return /^f/.test(typeof a) ? /c/.test(b.readyState) ? a() : $(b).on('DOMContentLoaded', a) : new i(a)
   }
 
+  // set prototype to array to inherit array behavior
+  $[d] = i[d] = $.fn = i.fn = c
+
   // set ki prototype
-  $[d] = i[d] = $.fn = i.fn = {
-
-    // default length
-    length: 0,
-
+  Object.assign($.fn, {
     /*
      * on method
      * a = string event type i.e 'click'
@@ -63,9 +62,5 @@
       c.forEach.call(this, a, b)
       return this
     },
-
-    // for some reason is needed to get an array-like
-    // representation instead of an object
-    splice: c.splice
-  }
+  })
 }(document, [], 'prototype');

--- a/ki.min.js
+++ b/ki.min.js
@@ -3,4 +3,4 @@
  * Copyright (c) 2015 Denis Ciccale (@tdecs)
  * Released under MIT license
  */
-!function(a,b,c,d){function e(c){b.push.apply(this,c&&c.nodeType?[c]:""+c===c?a.querySelectorAll(c):d)}$=function(b){return/^f/.test(typeof b)?/c/.test(a.readyState)?b():$(a).on("DOMContentLoaded",b):new e(b)},$[c]=e[c]=$.fn=e.fn={length:0,on:function(a,b){return this.each(function(c){c.addEventListener(a,b)})},off:function(a,b){return this.each(function(c){c.removeEventListener(a,b)})},each:function(a,c){return b.forEach.call(this,a,c),this},splice:b.splice}}(document,[],"prototype");
+!function(a,b,c,d){function e(c){b.push.apply(this,c&&c.nodeType?[c]:""+c===c?a.querySelectorAll(c):d)}$=function(b){return/^f/.test(typeof b)?/c/.test(a.readyState)?b():$(a).on("DOMContentLoaded",b):new e(b)},$[c]=e[c]=$.fn=e.fn=b,Object.assign($.fn,{on:function(a,b){return this.each(function(c){c.addEventListener(a,b)})},off:function(a,b){return this.each(function(c){c.removeEventListener(a,b)})},each:function(a,c){return b.forEach.call(this,a,c),this}})}(document,[],"prototype");

--- a/test/test.html
+++ b/test/test.html
@@ -2,7 +2,7 @@
 
   <link rel="stylesheet" href="qunit.css">
 
-  <p>Test</p>
+  <p id="p1">Test</p>
   <p>Test</p>
 
   <button id="btn">Click</button>

--- a/test/tests.js
+++ b/test/tests.js
@@ -23,7 +23,6 @@
   });
 
   test('wrap a DOM element with $', 1, function () {
-
     ok($(btn) instanceof $);
   });
 
@@ -57,4 +56,15 @@
     var noop = function(){};
     ok($ps.each(noop).on('click', noop).off('click', noop) === $ps);
   });
+
+  test('allow array methods', 2, function() {
+    var arr = $ps.map(e => e.textContent);
+    ok(arr.length === 2);
+    ok(arr[0] === "Test")
+  })
+
+  test('allow array access', 1, function() {
+    var e = $ps[0];
+    ok(e === document.getElementById("p1"));
+  })
 }());


### PR DESCRIPTION
This adds support for array methods and access with brackets.
```js
// <p>Hello</p><p>World</p>
$("p").map(p => p.textContent);
// ['Hello', 'World']
$("p")[0].textContent
// 'Hello'
```

Just set prototype as the array to inherit behavior.

_Note: this repo is really old but I love the concept. My fork will thus be implementing more modern features like using Bun as package manager and test runner, getting rid of IE support, etc. Tell me if you are interested @dciccale and I can create more PRs._