### PR TITLE
use $ as both factory and constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ki.js
 
-ki.js is a super-tiny jQuery-like API JavaScript library (460 bytes | 299 gzipped)
+ki.js is a super-tiny jQuery-like API JavaScript library (445 bytes | 282 gzipped)
 
 ### Browser support
 

--- a/ki.js
+++ b/ki.js
@@ -3,16 +3,7 @@
  * Copyright (c) 2015 Denis Ciccale (@tdecs)
  * Released under MIT license
  */
-!function (b, c, d, e) {
-
-  /*
-   * init function (internal use)
-   * a = selector, dom element or function
-   */
-  function i(a) {
-    c.push.apply(this, a && a.nodeType ? [a] : '' + a === a ? b.querySelectorAll(a) : e)
-  }
-
+!function (b, c, d) {
   /*
    * $ main function
    * a = css selector, dom object, or function
@@ -20,11 +11,13 @@
    * returns instance or executes function on ready
    */
   $ = function (a) {
-    return /^f/.test(typeof a) ? /c/.test(b.readyState) ? a() : $(b).on('DOMContentLoaded', a) : new i(a)
-  }
+    return this instanceof $
+      ? c.push.apply(this, a && a.nodeType ? [a] : '' + a === a ? b.querySelectorAll(a) : d) // constructor
+      : /^f/.test(typeof a) ? /c/.test(b.readyState) ? a() : $(b).on('DOMContentLoaded', a) : new $(a) // function
+  };
 
   // set prototype to array to inherit array behavior
-  $[d] = i[d] = $.fn = i.fn = c
+  $.prototype = $.fn = c
 
   // set ki prototype
   Object.assign($.fn, {
@@ -59,8 +52,8 @@
      * b = the this value for that function
      */
     each(a, b) {
-      c.forEach.call(this, a, b)
+      this.forEach(a, b)
       return this
     },
   })
-}(document, [], 'prototype');
+}(document, []);

--- a/ki.min.js
+++ b/ki.min.js
@@ -3,4 +3,4 @@
  * Copyright (c) 2015 Denis Ciccale (@tdecs)
  * Released under MIT license
  */
-!function(a,b,c,d){function e(c){b.push.apply(this,c&&c.nodeType?[c]:""+c===c?a.querySelectorAll(c):d)}$=function(b){return/^f/.test(typeof b)?/c/.test(a.readyState)?b():$(a).on("DOMContentLoaded",b):new e(b)},$[c]=e[c]=$.fn=e.fn=b,Object.assign($.fn,{on(a,b){return this.each(function(c){c.addEventListener(a,b)})},off(a,b){return this.each(function(c){c.removeEventListener(a,b)})},each(a,c){return b.forEach.call(this,a,c),this}})}(document,[],"prototype");
+!function(t,e,n){$=function(o){return this instanceof $?e.push.apply(this,o&&o.nodeType?[o]:""+o===o?t.querySelectorAll(o):n):/^f/.test(typeof o)?/c/.test(t.readyState)?o():$(t).on("DOMContentLoaded",o):new $(o)},$.prototype=$.fn=e,Object.assign($.fn,{on(t,e){return this.each((function(n){n.addEventListener(t,e)}))},off(t,e){return this.each((function(n){n.removeEventListener(t,e)}))},each(t,e){return this.forEach(t,e),this}})}(document,[]);


### PR DESCRIPTION
Use $ as factory - `$("div")` - and constructor - `new $` - to reduce byte size

This reduces byte size to 445 min / 282 gzip. It is very likely that this is the lowest we can get without changing ki.js functionality.

I updated README with the new values.